### PR TITLE
Increase guide legibility

### DIFF
--- a/_sass/_myStyle.scss
+++ b/_sass/_myStyle.scss
@@ -65,6 +65,6 @@ body.frontpage {
 }
 
 body.guide .container {
-    background: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.95);
     margin: 1em auto;
 }


### PR DESCRIPTION
Transparent backgrounds look cool, but it makes the text hard to read.

![image](https://cloud.githubusercontent.com/assets/578029/6321018/20f59b18-baef-11e4-9a2d-049cf1b3d9d7.png)
