### PR TITLE
Remove baseurl config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 name: Sagaen om Harald Blåtann
 highlighter: rouge
-baseurl: /
 markdown: redcarpet
 
 exclude: ["Gemfile", "Gemfile.lock", "README.md", "LICENCE", "Makefile"]


### PR DESCRIPTION
The baseurl we want is "", not /, and "" is already default. Therefore,
we can simply remove the baseurl config.
