### PR TITLE
Switch highlighter back to pygments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
-gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,6 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.2.2)
-    rouge (1.8.0)
     safe_yaml (1.0.4)
     sass (3.4.12)
     timers (4.0.1)
@@ -69,4 +68,3 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
-  rouge

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: Sagaen om Harald Blåtann
-highlighter: rouge
+highlighter: pygments
 baseurl: /
 markdown: redcarpet
 


### PR DESCRIPTION
Rouge turned out not to be supported on gh pages, so the builds stopped working.

I assumed rouge was better because it's written in ruby, vs. pygments which is a python package.
Anyway, pygments seems to be working much better.
