### PR TITLE
Linkify title in guide pages

### DIFF
--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -18,7 +18,7 @@
           <li><a href="">Home</a></li>
           <li class="active"><a href="slides/">Slides</a></li>
         </ul>
-        <h3>{{ site.name }}</h3>
+        <h3><a href="">{{ site.name }}</a></h3>
       </div>
 
       <div class=banner style=background-image:url('{{ page.banner }}')>

--- a/_sass/_myStyle.scss
+++ b/_sass/_myStyle.scss
@@ -67,6 +67,11 @@ body.guide .container {
     margin: 1em auto;
     font-size: 17px;
 
+    h3 a {
+        text-decoration: none;
+        color: black;
+    }
+
     .banner {
         height: 300px;
         background: #eee no-repeat center center;


### PR DESCRIPTION
This is now a link that goes to the frontpage:

![image](https://cloud.githubusercontent.com/assets/578029/6355375/d8f841ea-bc55-11e4-9966-9760017df6d3.png)
